### PR TITLE
增加缓存控制中间件

### DIFF
--- a/pkg/middleware/handler.go
+++ b/pkg/middleware/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tsingsun/woocoo/web"
 	"github.com/tsingsun/woocoo/web/handler"
 	"github.com/tsingsun/woocoo/web/handler/signer"
+	"github.com/woocoos/entcache"
 	"github.com/woocoos/knockout-go/pkg/identity"
 	"net/http"
 	"strconv"
@@ -102,5 +103,82 @@ func TenantIDMiddleware(cfg *conf.Configuration) gin.HandlerFunc {
 			return
 		}
 		handler.DerivativeContextWithValue(c, identity.TenantContextKey, v)
+	}
+}
+
+// RegisterCacheControl register middleware to set skip cache from request header
+func RegisterCacheControl() web.Option {
+	return web.WithMiddlewareApplyFunc("cachectl", CacheControlMiddleware)
+}
+
+type CacheControlConfig struct {
+	Lookup     string
+	RootDomain string
+	Exclude    []string
+	Skipper    handler.Skipper
+}
+
+// CacheControlMiddleware returns middleware to set skip cache from request header
+func CacheControlMiddleware(cfg *conf.Configuration) gin.HandlerFunc {
+	// 更简单的方式，但不确定是否好
+	//return func(c *gin.Context) {
+	//	ctx := handler.GetDerivativeContext(c)
+	//	req := graphql.GetOperationContext(ctx)
+	//	cacheControl := req.Headers.Get("Cache-Control")
+	//	if cacheControl == "no-cache" {
+	//		ctx = entcache.Skip(ctx)
+	//		handler.SetDerivativeContext(c, ctx)
+	//	}
+	//}
+
+	opts := CacheControlConfig{
+		Lookup: "header:" + "Cache-Control",
+	}
+	if err := cfg.Unmarshal(&opts); err != nil {
+		panic(err)
+	}
+	if opts.Skipper == nil {
+		opts.Skipper = handler.PathSkipper(opts.Exclude)
+	}
+	var findValue func(c *gin.Context) (string, error)
+	switch opts.Lookup {
+	case "host":
+		findValue = func(c *gin.Context) (str string, err error) {
+			host := c.Request.Host
+			if len(opts.RootDomain) > 0 {
+				str = host[:len(host)-len(opts.RootDomain)-1]
+			}
+			return
+		}
+	default:
+		findValue = func(c *gin.Context) (str string, err error) {
+			extr, err := handler.CreateExtractors(opts.Lookup, "")
+			if err != nil {
+				return
+			}
+			for _, extractor := range extr {
+				ts, err := extractor(c)
+				if err == nil && len(ts) != 0 {
+					str = ts[0]
+					break
+				}
+			}
+			return
+		}
+	}
+	return func(c *gin.Context) {
+		if opts.Skipper(c) {
+			return
+		}
+		cacheControl, err := findValue(c)
+		if err != nil {
+			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("get cache control error: %v", err))
+			return
+		}
+		if cacheControl == "no-cache" {
+			ctx := handler.GetDerivativeContext(c)
+			ctx = entcache.Skip(ctx)
+			handler.SetDerivativeContext(c, ctx)
+		}
 	}
 }

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -132,7 +132,7 @@ engine:
   routerGroups:
   - default:
       middlewares:
-      - cachectl:
+      - cacheControl:
 `))),
 			RegisterCacheControl(),
 		)

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -125,6 +125,9 @@ engine:
 		w := httptest.NewRecorder()
 		router.Router().ServeHTTP(w, req)
 	})
+}
+
+func TestCacheControlMiddleware(t *testing.T) {
 	t.Run("web-cache-control", func(t *testing.T) {
 		router := web.New(
 			web.WithConfiguration(conf.NewFromBytes([]byte(`

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -125,4 +125,23 @@ engine:
 		w := httptest.NewRecorder()
 		router.Router().ServeHTTP(w, req)
 	})
+	t.Run("web-cache-control", func(t *testing.T) {
+		router := web.New(
+			web.WithConfiguration(conf.NewFromBytes([]byte(`
+engine:
+  routerGroups:
+  - default:
+      middlewares:
+      - cachectl:
+`))),
+			RegisterCacheControl(),
+		)
+		router.Router().GET("/test", func(c *gin.Context) {
+			c.String(200, "test")
+		})
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Cache-Control", "no-cache")
+		w := httptest.NewRecorder()
+		router.Router().ServeHTTP(w, req)
+	})
 }


### PR DESCRIPTION
添加CacheControlMiddleware的中间件，当拦截到Header里面的Cache-Control，判断值为no-cache，则调用entcache.skip(ctx)